### PR TITLE
fix: MDX content rendering for gatsby-plugin-mdx v5

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,6 +44,9 @@ exports.createPages = async ({ graphql, actions }) => {
             fields {
               slug
             }
+            internal {
+              contentFilePath
+            }
             frontmatter {
               title
               categories
@@ -62,7 +65,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
     createPage({
       path: n.fields.slug,
-      component: postTemplate,
+      component: `${postTemplate}?__contentFilePath=${n.internal.contentFilePath}`,
       context: {
         slug: n.fields.slug,
         prev,

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -51,7 +51,7 @@ const PostContent = styled.div`
   margin-top: 4rem;
 `
 
-const Post = ({ pageContext: { slug, prev, next }, data: { mdx: postNode } }) => {
+const Post = ({ pageContext: { slug, prev, next }, data: { mdx: postNode }, children }) => {
   const post = postNode.frontmatter
 
   return (
@@ -73,7 +73,7 @@ const Post = ({ pageContext: { slug, prev, next }, data: { mdx: postNode } }) =>
             ))}
           </Subline>
           <PostContent>
-            {postNode.children}
+            {children}
           </PostContent>
           <PrevNext prev={prev} next={next} />
         </Content>
@@ -105,7 +105,6 @@ Post.defaultProps = {
 export const postQuery = graphql`
   query postBySlug($slug: String!) {
     mdx(fields: { slug: { eq: $slug } }) {
-      children
       excerpt
       frontmatter {
         title


### PR DESCRIPTION
- Update gatsby-node.js to include contentFilePath in page creation
- Use __contentFilePath parameter for proper MDX content passing
- Simplify post template to rely on children prop for content
- Remove complex body evaluation that was causing parsing errors

This fixes the issue where blog post bodies were not displaying in the post pages by properly integrating with gatsby-plugin-mdx v5.